### PR TITLE
Add clear pair function

### DIFF
--- a/civilcode.zshrc
+++ b/civilcode.zshrc
@@ -1,3 +1,8 @@
 source $HOME/.civilcode.erlang
 
+function clear-pair(){
+  git config --unset user.name
+  git config --unset user.email
+}
+
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local


### PR DESCRIPTION
**Usage**
Reset a user after having set a pair with `git-pair`.
There was a [PR](https://github.com/chrisk/git-pair/pull/2) in the `git-pair` project that never got merged unfortunately

Run `rcup` to update configuration files once pulled locally. 

**Workflow**
```
➜  platform git:(master) ✗ git config -l | grep user
user.name=Nicolas Charlery
user.email=nicolas@bokay.io

➜  platform git:(master) ✗ git pair TD
  Current author: Tetiana Dushenkivska
   Current email: nicolas.charlery+td@civilcode.io

➜  platform git:(master) ✗ git config -l | grep user
user.name=Nicolas Charlery
user.email=nicolas@bokay.io
user.name=Tetiana Dushenkivska
user.email=nicolas.charlery+td@civilcode.io

➜  platform git:(master) ✗ clear-pair
➜  platform git:(master) ✗ git config -l | grep user
user.name=Nicolas Charlery
user.email=nicolas@bokay.io
```