### PR TITLE
Avoid compiling erlang for Java

### DIFF
--- a/civilcode.erlang
+++ b/civilcode.erlang
@@ -1,1 +1,2 @@
 export ERL_AFLAGS="-kernel shell_history enabled"
+export KERL_CONFIGURE_OPTIONS="--disable-debug --without-javac"


### PR DESCRIPTION
This will result in faster compilation of erlang when upgrading to a newer version.
Ref: https://github.com/asdf-vm/asdf-erlang#use