### PR TITLE
Make deamc alias bash compatible

### DIFF
--- a/civilcode.shrc
+++ b/civilcode.shrc
@@ -10,19 +10,38 @@ alias deamc="_mix_command_in_child_app"
 alias deatmc="_mix_command_in_child_app_test"
 alias elixir-format="watchman -- trigger ./ format '**/*.ex' '**/*.exs' '**/*.default' -- mix format"
 
-_docker_compose_exec() {
-	docker-compose exec -e ERL_AFLAGS='-kernel shell_history enabled' $*
-}
+if [ "$SHELL" = "/bin/bash" ]; then
+	function _docker_compose_exec() {
+	       	env_part=$( printf '"%q"  ' "-kernel shell_history enabled") 
+	     	docker-compose exec -e ERL_AFLAGS="${env_part}" ${1} "${2}"
+	}
+	
+	function _mix_command_in_child_app() {
+		app="$1"; shift
+		_docker_compose_exec "application bash -c" "cd /app/apps/$app && $*"
+	}
+	
+	function _mix_command_in_child_app_test() {
+		app="$1"; shift
+		_docker_compose_exec "-e MIX_ENV=test application bash -c" "cd /app/apps/$app && $*"
+	}
 
-_mix_command_in_child_app() {
-	app="$1"; shift
-	_docker_compose_exec application bash -c "cd /app/apps/$app && $*"
-}
+else
+	function _docker_compose_exec() {
+		docker-compose exec -e ERL_AFLAGS='-kernel shell_history enabled' $*
+	}
+	
+	function _mix_command_in_child_app() {
+		app="$1"; shift
+		_docker_compose_exec application bash -c "cd /app/apps/$app && $*"
+	}
+	
+	function _mix_command_in_child_app_test() {
+		app="$1"; shift
+		_docker_compose_exec -e MIX_ENV=test application bash -c "cd /app/apps/$app && $*"
+	}
 
-_mix_command_in_child_app_test() {
-	app="$1"; shift
-	_docker_compose_exec -e MIX_ENV=test application bash -c "cd /app/apps/$app && $*"
-}
+fi
 
 # env
 

--- a/civilcode.shrc
+++ b/civilcode.shrc
@@ -2,10 +2,12 @@ source $HOME/.civilcode.erlang
 
 # aliases
 
-alias dea="_docker_compose_exec application"
-alias deat="_docker_compose_exec -e MIX_ENV=test application"
-alias deam="_docker_compose_exec application mix"
-alias deatm="_docker_compose_exec -e MIX_ENV=test application mix"
+alias dea="docker-compose exec -e ERL_AFLAGS='-kernel shell_history enabled' application"
+alias deat="docker-compose exec -e ERL_AFLAGS='-kernel shell_history enabled' -e MIX_ENV=test application"
+
+alias deam="dea mix"
+alias deatm="deat mix"
+
 alias deamc="_mix_command_in_child_app"
 alias deatmc="_mix_command_in_child_app_test"
 alias elixir-format="watchman -- trigger ./ format '**/*.ex' '**/*.exs' '**/*.default' -- mix format"


### PR DESCRIPTION
The alias `deamc` does not run on bash. Make sure all other aliases work on bash.

- [ ] Test all aliases on Cloud9 MAX 30 MINUTES

See  #20