### PR TITLE
Add bash command to build a slack checkout draft

### DIFF
--- a/civilcode.shrc
+++ b/civilcode.shrc
@@ -51,12 +51,13 @@ function _prepare_slack_checkout() {
 	date="${1:-$(date +"%Y%m%d")}"
 	github_user=$(security find-internet-password -s github.com | grep acct | sed 's/^.*="\(.*\)".*$/\1/')
 
-	base_hub_options=(--include-pulls -a $github_user -d $date)
-	open_issues=$(hub issue $base_hub_options -s open -f "• in-progress: _%t_; add details%n%U%n")
-	closed_issues=$(hub issue $base_hub_options -s closed -f "• completed: _%t_; add details%n%U%n")
+	base_hub_options=(--include-pulls --sort updated -a $github_user -d $date)
+	open_issues=$(hub issue $base_hub_options -s open -f "• in-progress: _%t_; STATUS%n%U%n")
+	closed_issues=$(hub issue $base_hub_options -s closed -f "• completed: _%t_%n%U%n")
 
 	checkout_message="$open_issues\n$closed_issues"
-	echo $checkout_message | pbcopy
+	# Use sed to reverse lines
+	echo $checkout_message | sed '1!G;h;$!d' | pbcopy
 	echo "THE FOLLOWING LINES HAVE BEEN COPIED TO YOUR BUFFER:\n$checkout_message"
 }
 

--- a/civilcode.shrc
+++ b/civilcode.shrc
@@ -14,8 +14,8 @@ alias elixir-format="watchman -- trigger ./ format '**/*.ex' '**/*.exs' '**/*.de
 
 if [ "$SHELL" = "/bin/bash" ]; then
 	function _docker_compose_exec() {
-	       	env_part=$( printf '"%q"  ' "-kernel shell_history enabled")
-	     	docker-compose exec -e ERL_AFLAGS="${env_part}" ${1} "${2}"
+	  env_part=$( printf '"%q"  ' "-kernel shell_history enabled")
+	  docker-compose exec -e ERL_AFLAGS="${env_part}" ${1} "${2}"
 	}
 
 	function _mix_command_in_child_app() {
@@ -42,7 +42,6 @@ else
 		app="$1"; shift
 		_docker_compose_exec -e MIX_ENV=test application bash -c "cd /app/apps/$app && $*"
 	}
-
 fi
 
 # env

--- a/civilcode.shrc
+++ b/civilcode.shrc
@@ -47,7 +47,8 @@ else
 fi
 
 function _prepare_slack_checkout() {
-	date=$(date +"%Y%m%d")
+	# Optional argument: date (format YYYYMMDD)
+	date="${1:-$(date +"%Y%m%d")}"
 	github_user=$(security find-internet-password -s github.com | grep acct | sed 's/^.*="\(.*\)".*$/\1/')
 
 	base_hub_options=(--include-pulls -a $github_user -d $date)

--- a/civilcode.shrc
+++ b/civilcode.shrc
@@ -12,6 +12,8 @@ alias deamc="_mix_command_in_child_app"
 alias deatmc="_mix_command_in_child_app_test"
 alias elixir-format="watchman -- trigger ./ format '**/*.ex' '**/*.exs' '**/*.default' -- mix format"
 
+alias sco="_prepare_slack_checkout"
+
 if [ "$SHELL" = "/bin/bash" ]; then
 	function _docker_compose_exec() {
 	  env_part=$( printf '"%q"  ' "-kernel shell_history enabled")
@@ -43,6 +45,19 @@ else
 		_docker_compose_exec -e MIX_ENV=test application bash -c "cd /app/apps/$app && $*"
 	}
 fi
+
+function _prepare_slack_checkout() {
+	date=$(date +"%Y%m%d")
+	github_user=$(security find-internet-password -s github.com | grep acct | sed 's/^.*="\(.*\)".*$/\1/')
+
+	base_hub_options=(--include-pulls -a $github_user -d $date)
+	open_issues=$(hub issue $base_hub_options -s open -f "• in-progress: _%t_; add details%n%U%n")
+	closed_issues=$(hub issue $base_hub_options -s closed -f "• completed: _%t_; add details%n%U%n")
+
+	checkout_message="$open_issues\n$closed_issues"
+	echo $checkout_message | pbcopy
+	echo "THE FOLLOWING LINES HAVE BEEN COPIED TO YOUR BUFFER:\n$checkout_message"
+}
 
 # env
 


### PR DESCRIPTION
To speed up our checkout and not miss anything that was pushed to github.

Prompt the user for the Github user handle (unless there is a way to get it - don't forget about the pairing account set-up). Get the open/closed issues and pull requests assigned to me that were updated today, build a draft for the checkout and put it in the buffer

```
{ hub issue --include-pulls -a "frahugo" -f "• %S: _%t_; more details%n%U%n" -d `date +"%Y%m%d"` -s closed & hub issue --include-pulls -a "frahugo" -f "• %S: _%t_; more details%n%U%n" -d `date +"%Y%m%d"` -s open ; } | pbcopy
```